### PR TITLE
Wrap migration jobs with a condition

### DIFF
--- a/charts/catalog/templates/migration-job.yaml
+++ b/charts/catalog/templates/migration-job.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.migration.enabled -}}
 kind: ServiceAccount
 apiVersion: v1
 metadata:
@@ -146,3 +147,4 @@ spec:
           volumeMounts:
           - name: storage
             mountPath: /data
+{{- end }}

--- a/charts/catalog/templates/pre-migration-job.yaml
+++ b/charts/catalog/templates/pre-migration-job.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.migration.enabled -}}
 kind: ServiceAccount
 apiVersion: v1
 metadata:
@@ -156,3 +157,4 @@ spec:
           volumeMounts:
           - name: storage
             mountPath: /data
+{{- end }}

--- a/charts/catalog/values.yaml
+++ b/charts/catalog/values.yaml
@@ -136,3 +136,6 @@ persistence:
 # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
 # PriorityClass: system-cluster-critical
 priorityClassName: ""
+
+migration:
+  enabled: true


### PR DESCRIPTION
## Description

Make migration job run optional.

Migration is enabled by default for backward compatibility. To disable the migration job, specify the following configuration in your values.yaml:

```yaml
migration:
  enabled: false
```