### PR TITLE
CRS-1536: Auto restart service-catalog when the TLS secret changes

### DIFF
--- a/charts/catalog/templates/webhook-deployment.yaml
+++ b/charts/catalog/templates/webhook-deployment.yaml
@@ -7,6 +7,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+{{- if and (.Values.webhook.tls.caInjectFrom) (.Values.webhook.tls.secret) }}
+  annotations:
+    rollout.restart/auto: "true"
+{{- end }}
 spec:
   replicas: 1
   strategy: {{ toYaml .Values.webhook.strategy | nindent 4 }}


### PR DESCRIPTION
This PR will use `reloader` (https://github.com/hellofresh/hf-kubernetes/pull/3829) to restart the webhook deployment when the TLS certificate is renewed.