### PR TITLE
CRS-1536: Helm does not have an explicit 'latest' version

### DIFF
--- a/ci/scripts/create-chart.sh
+++ b/ci/scripts/create-chart.sh
@@ -36,8 +36,3 @@ user_args="${user_args} --header X-Checksum-MD5:${CHART_PACKAGE_MD5} --header X-
 
 # Upload package
 curl $user_args --fail --upload-file "${CHART_PACKAGE_PATH}" "${CHART_REPO}/${CHART_PACKAGE}"
-
-if [ "${TAG_AS_LATEST}" = "true" ]; then
-  CHART_LATEST="${CHART_NAME}-latest.tgz"
-  curl $user_args --fail --upload-file "${CHART_PACKAGE_PATH}" "${CHART_REPO}/${CHART_LATEST}"
-fi

--- a/ci/tasks/create-chart.yml
+++ b/ci/tasks/create-chart.yml
@@ -22,4 +22,3 @@ params:
   VERSION_FILE: version/version
   ARTIFACTORY_USERNAME: ((defaults.artifactory_user))
   ARTIFACTORY_PASSWORD: ((defaults.artifactory_pass))
-  TAG_AS_LATEST: true


### PR DESCRIPTION
This PR removes the `TAG_AS_LATEST` functionality since it does not apply to `helm`  (only to `docker`) artifacts. More info https://hellofresh.slack.com/archives/GBXJ28GRL/p1615998646007000