### PR TITLE
CRS-1195/deprecated k8s resources

### DIFF
--- a/charts/catalog/Chart.yaml
+++ b/charts/catalog/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 name: catalog
 description: service-catalog webhook server and controller-manager helm chart
-version: 0.3.2
+version: 0.3.3

--- a/charts/catalog/templates/crds/clusterservicebroker.yaml
+++ b/charts/catalog/templates/crds/clusterservicebroker.yaml
@@ -6,7 +6,6 @@ metadata:
     svcat: "true"
 spec:
   group: servicecatalog.k8s.io
-  version: v1beta1
   scope: Cluster
   names:
     plural: clusterservicebrokers
@@ -16,15 +15,19 @@ spec:
     categories:
       - all
       - svcat
-  additionalPrinterColumns:
-    - name: URL
-      type: string
-      JSONPath: .spec.url
-    - name: Status
-      type: string
-      JSONPath: .status.lastConditionState
-    - name: Age
-      type: date
-      JSONPath: .metadata.creationTimestamp
-  subresources:
-    status: {}
+  versions:
+    - additionalPrinterColumns:
+      - name: URL
+        type: string
+        jsonPath: .spec.url
+      - name: Status
+        type: string
+        jsonPath: .status.lastConditionState
+      - name: Age
+        type: date
+        jsonPath: .metadata.creationTimestamp
+      name: v1beta1
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/charts/catalog/templates/crds/clusterserviceclass.yaml
+++ b/charts/catalog/templates/crds/clusterserviceclass.yaml
@@ -6,7 +6,6 @@ metadata:
     svcat: "true"
 spec:
   group: servicecatalog.k8s.io
-  version: v1beta1
   scope: Cluster
   names:
     plural: clusterserviceclasses
@@ -16,15 +15,19 @@ spec:
     categories:
       - all
       - svcat
-  additionalPrinterColumns:
-    - name: External-Name
-      type: string
-      JSONPath: .spec.externalName
-    - name: Broker
-      type: string
-      JSONPath: .spec.clusterServiceBrokerName
-    - name: Age
-      type: date
-      JSONPath: .metadata.creationTimestamp
-  subresources:
-    status: {}
+  versions:
+    - additionalPrinterColumns:
+      - name: External-Name
+        type: string
+        jsonPath: .spec.externalName
+      - name: Broker
+        type: string
+        jsonPath: .spec.clusterServiceBrokerName
+      - name: Age
+        type: date
+        jsonPath: .metadata.creationTimestamp
+      name: v1beta1
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/charts/catalog/templates/crds/clusterserviceplan.yaml
+++ b/charts/catalog/templates/crds/clusterserviceplan.yaml
@@ -6,7 +6,6 @@ metadata:
     svcat: "true"
 spec:
   group: servicecatalog.k8s.io
-  version: v1beta1
   scope: Cluster
   names:
     plural: clusterserviceplans
@@ -16,18 +15,22 @@ spec:
     categories:
       - all
       - svcat
-  additionalPrinterColumns:
-    - name: External-Name
-      type: string
-      JSONPath: .spec.externalName
-    - name: Broker
-      type: string
-      JSONPath: .spec.clusterServiceBrokerName
-    - name: Class
-      type: string
-      JSONPath: .spec.clusterServiceClassRef.name
-    - name: Age
-      type: date
-      JSONPath: .metadata.creationTimestamp
-  subresources:
-    status: {}
+  versions:
+    - additionalPrinterColumns:
+      - name: External-Name
+        type: string
+        jsonPath: .spec.externalName
+      - name: Broker
+        type: string
+        jsonPath: .spec.clusterServiceBrokerName
+      - name: Class
+        type: string
+        jsonPath: .spec.clusterServiceClassRef.name
+      - name: Age
+        type: date
+        jsonPath: .metadata.creationTimestamp
+      name: v1beta1
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/charts/catalog/templates/crds/servicebinding.yaml
+++ b/charts/catalog/templates/crds/servicebinding.yaml
@@ -6,7 +6,6 @@ metadata:
     svcat: "true"
 spec:
   group: servicecatalog.k8s.io
-  version: v1beta1
   scope: Namespaced
   names:
     plural: servicebindings
@@ -16,18 +15,22 @@ spec:
     categories:
       - all
       - svcat
-  additionalPrinterColumns:
-    - name: Service-Instance
-      type: string
-      JSONPath: .spec.instanceRef.name
-    - name: Secret-Name
-      type: string
-      JSONPath: .spec.secretName
-    - name: Status
-      type: string
-      JSONPath: .status.lastConditionState
-    - name: Age
-      type: date
-      JSONPath: .metadata.creationTimestamp
-  subresources:
-    status: {}
+  versions:
+    - additionalPrinterColumns:
+      - name: Service-Instance
+        type: string
+        jsonPath: .spec.instanceRef.name
+      - name: Secret-Name
+        type: string
+        jsonPath: .spec.secretName
+      - name: Status
+        type: string
+        jsonPath: .status.lastConditionState
+      - name: Age
+        type: date
+        jsonPath: .metadata.creationTimestamp
+      name: v1beta1
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/charts/catalog/templates/crds/servicebroker.yaml
+++ b/charts/catalog/templates/crds/servicebroker.yaml
@@ -6,7 +6,6 @@ metadata:
     svcat: "true"
 spec:
   group: servicecatalog.k8s.io
-  version: v1beta1
   scope: Namespaced
   names:
     plural: servicebrokers
@@ -16,15 +15,19 @@ spec:
     categories:
       - all
       - svcat
-  additionalPrinterColumns:
-    - name: URL
-      type: string
-      JSONPath: .spec.url
-    - name: Status
-      type: string
-      JSONPath: .status.lastConditionState
-    - name: Age
-      type: date
-      JSONPath: .metadata.creationTimestamp
-  subresources:
-    status: {}
+  versions:
+    - additionalPrinterColumns:
+      - name: URL
+        type: string
+        jsonPath: .spec.url
+      - name: Status
+        type: string
+        jsonPath: .status.lastConditionState
+      - name: Age
+        type: date
+        jsonPath: .metadata.creationTimestamp
+      name: v1beta1
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/charts/catalog/templates/crds/serviceclass.yaml
+++ b/charts/catalog/templates/crds/serviceclass.yaml
@@ -6,7 +6,6 @@ metadata:
     svcat: "true"
 spec:
   group: servicecatalog.k8s.io
-  version: v1beta1
   scope: Namespaced
   names:
     plural: serviceclasses
@@ -16,15 +15,19 @@ spec:
     categories:
       - all
       - svcat
-  additionalPrinterColumns:
-    - name: External-Name
-      type: string
-      JSONPath: .spec.externalName
-    - name: Broker
-      type: string
-      JSONPath: .spec.serviceBrokerName
-    - name: Age
-      type: date
-      JSONPath: .metadata.creationTimestamp
-  subresources:
-    status: {}
+  versions:
+    - additionalPrinterColumns:
+      - name: External-Name
+        type: string
+        jsonPath: .spec.externalName
+      - name: Broker
+        type: string
+        jsonPath: .spec.serviceBrokerName
+      - name: Age
+        type: date
+        jsonPath: .metadata.creationTimestamp
+      name: v1beta1
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/charts/catalog/templates/crds/serviceinstance.yaml
+++ b/charts/catalog/templates/crds/serviceinstance.yaml
@@ -6,7 +6,6 @@ metadata:
     svcat: "true"
 spec:
   group: servicecatalog.k8s.io
-  version: v1beta1
   scope: Namespaced
   names:
     plural: serviceinstances
@@ -16,18 +15,22 @@ spec:
     categories:
       - all
       - svcat
-  additionalPrinterColumns:
-    - name: Class
-      type: string
-      JSONPath: .status.userSpecifiedClassName
-    - name: Plan
-      type: string
-      JSONPath: .status.userSpecifiedPlanName
-    - name: Status
-      type: string
-      JSONPath: .status.lastConditionState
-    - name: Age
-      type: date
-      JSONPath: .metadata.creationTimestamp
-  subresources:
-    status: {}
+  versions:
+    - additionalPrinterColumns:
+      - name: Class
+        type: string
+        jsonPath: .status.userSpecifiedClassName
+      - name: Plan
+        type: string
+        jsonPath: .status.userSpecifiedPlanName
+      - name: Status
+        type: string
+        jsonPath: .status.lastConditionState
+      - name: Age
+        type: date
+        jsonPath: .metadata.creationTimestamp
+      name: v1beta1
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/charts/catalog/templates/crds/serviceplan.yaml
+++ b/charts/catalog/templates/crds/serviceplan.yaml
@@ -6,7 +6,6 @@ metadata:
     svcat: "true"
 spec:
   group: servicecatalog.k8s.io
-  version: v1beta1
   scope: Namespaced
   names:
     plural: serviceplans
@@ -16,18 +15,22 @@ spec:
     categories:
       - all
       - svcat
-  additionalPrinterColumns:
-    - name: External-Name
-      type: string
-      JSONPath: .spec.externalName
-    - name: Broker
-      type: string
-      JSONPath: .spec.serviceBrokerName
-    - name: Class
-      type: string
-      JSONPath: .spec.serviceClassRef.name
-    - name: Age
-      type: date
-      JSONPath: .metadata.creationTimestamp
-  subresources:
-    status: {}
+  versions:
+    - additionalPrinterColumns:
+      - name: External-Name
+        type: string
+        jsonPath: .spec.externalName
+      - name: Broker
+        type: string
+        jsonPath: .spec.serviceBrokerName
+      - name: Class
+        type: string
+        jsonPath: .spec.serviceClassRef.name
+      - name: Age
+        type: date
+        jsonPath: .metadata.creationTimestamp
+      name: v1beta1
+      served: true
+      storage: true
+      subresources:
+        status: {}


### PR DESCRIPTION
Spec definition updates for manifests 
service-catalog chart contains CustomResourceDefinition manifests in API group apiextensions.k8s.io/v1beta1 that is deprecated in favor of apiextensions.k8s.io/v1.